### PR TITLE
Fix 'Unnecessary &quot;elif&quot; after &quot;return&quot;' issue in tests\worker_test_001.py

### DIFF
--- a/tests/worker_test_001.py
+++ b/tests/worker_test_001.py
@@ -27,8 +27,7 @@ class MySocketClient:
             return True, content.strip("--eof--")
         elif content != "--eof--":
             return False, content.strip("--eof--")
-        else:
-            return True, ""
+        return True, ""
 
     async def _get_resp(self):
         full_content = ""


### PR DESCRIPTION
Fix 'Unnecessary &quot;elif&quot; after &quot;return&quot;' issue in tests\worker_test_001.py